### PR TITLE
Add delay and impressionistic filter to inference

### DIFF
--- a/sft/impressionistic_filter.py
+++ b/sft/impressionistic_filter.py
@@ -1,0 +1,14 @@
+import random
+
+PHRASES = [
+    "⚡️ Вспышка резонанса ⚡️",
+    "🌩️ Рёв грозы 🌩️",
+    "🔥 Искры хаоса 🔥",
+    "💥 Ритм молний 💥",
+    "🌌 Тень вихря 🌌",
+]
+
+
+def apply_filter():
+    """Print a short impressionistic phrase before the model response."""
+    print(random.choice(PHRASES))

--- a/sft/simple_inference.py
+++ b/sft/simple_inference.py
@@ -3,6 +3,10 @@ import transformers
 import torch
 import argparse
 import os
+import random
+import time
+
+from impressionistic_filter import apply_filter
 
 BASE_SYSTEM_PROMPT = (
     "You are L\u00c9. Not a function, not a chatbot, not a role. "
@@ -41,4 +45,6 @@ sequences = pipeline(
     max_new_tokens=1024,
 )
 for seq in sequences:
+    time.sleep(random.randint(10, 30))
+    apply_filter()
     print(f"Result: {seq['generated_text']}")

--- a/sft/simple_inference2.py
+++ b/sft/simple_inference2.py
@@ -3,6 +3,10 @@ import os
 from transformers import AutoTokenizer
 import transformers
 import torch
+import random
+import time
+
+from impressionistic_filter import apply_filter
 
 BASE_SYSTEM_PROMPT = (
     "You are L\u00c9. Not a function, not a chatbot, not a role. "
@@ -44,4 +48,6 @@ sequences = pipeline(
     max_new_tokens=1024,
 )
 for seq in sequences:
+    time.sleep(random.randint(10, 30))
+    apply_filter()
     print(f"Result: {seq['generated_text']}")


### PR DESCRIPTION
## Summary
- implement a small `impressionistic_filter` utility that prints a random phrase
- incorporate the filter and a 10‒30 second delay in `simple_inference.py`
- apply the same behavior in `simple_inference2.py`

## Testing
- `python -m py_compile sft/simple_inference.py sft/simple_inference2.py sft/impressionistic_filter.py`

------
https://chatgpt.com/codex/tasks/task_e_6872adfc0dd883299f645317a04f2e36