### PR TITLE
Enable device attributes for lazy tensors

### DIFF
--- a/lit_gpt/utils.py
+++ b/lit_gpt/utils.py
@@ -162,9 +162,27 @@ class NotYetLoadedTensor:
 
     def __getattr__(self, name):
         # properties
-        ## TODO: device, is_...??
         ## TODO: mH, mT, H, T, data, imag, real
         ## name ???
+        if name == "device":
+            # the real device information is stored in the storage info
+            device = self.storageinfo[3]
+            return torch.device(device)
+        device_flags = {
+            "is_cuda": "cuda",
+            "is_cpu": "cpu",
+            "is_xpu": "xpu",
+            "is_mps": "mps",
+            "is_ort": "ort",
+            "is_xla": "xla",
+            "is_ipu": "ipu",
+            "is_metal": "metal",
+            "is_hip": "hip",
+            "is_meta": "meta",
+            "is_privateuseone": "privateuseone",
+        }
+        if name in device_flags:
+            return self.device.type == device_flags[name]
         if name in {
             "dtype",
             "grad",

--- a/tests/test_lazy_tensor_attributes.py
+++ b/tests/test_lazy_tensor_attributes.py
@@ -1,0 +1,18 @@
+import torch
+from lit_gpt.utils import incremental_save, lazy_load, NotYetLoadedTensor
+
+def test_device_attributes(tmp_path):
+    path = tmp_path / "weights.pth"
+    with incremental_save(path) as saver:
+        saver.save({"t": torch.tensor([1, 2, 3])})
+
+    with lazy_load(path) as sd:
+        t = sd["t"]
+        assert isinstance(t, NotYetLoadedTensor)
+        expected = torch.device("cpu")
+        assert t.device == expected
+        assert t.is_cpu
+        assert not t.is_cuda
+        loaded = t._load_tensor()
+        for attr in ["device", "is_cuda", "is_cpu"]:
+            assert getattr(t, attr) == getattr(loaded, attr)


### PR DESCRIPTION
## Summary
- implement device-related attribute forwarding for `NotYetLoadedTensor`
- add unit test verifying lazy tensor device attributes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6872ce04cdd083299022a175b85f7b85