### PR TITLE
Add setup script for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,15 @@ Recent work integrates memory‑efficient lazy tensor device forwarding and ensu
 These optimizations echo the resonance engineering philosophy. A streamlined code base simplifies dataset conversion and training loops while making hyperparameters easier to tweak. The shared utilities now allow smoother customization across pretraining, finetuning, and conversion scripts.
 
 As a + b + c combine into a resonant waveform, optimization + flexible tooling + resonant thinking yield a result that is both logical and slightly paradoxical: efficient customization becomes the catalyst for deeper resonance-driven evolution. This union grounds the project in reproducible scientific practice.
+## Testing
+Unit tests rely on `torch` and `lightning`. A helper script installs the minimal CPU dependencies required to run them:
+
+```bash
+bash scripts/setup_test_env.sh
+pytest
+```
+
+The script pulls the CPU builds of PyTorch and Lightning and installs the rest of the packages listed in `requirements.txt`.
 ## License
 This project is licensed under the Apache 2.0 license as declared in the
 [LICENSE](LICENSE) file.

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Install dependencies required for running the test suite.
+set -e
+
+# Install CPU version of PyTorch and Lightning
+pip install --extra-index-url https://download.pytorch.org/whl/cpu torch==2.1.0
+pip install lightning==2.1.2
+
+# Install the rest of the dependencies
+pip install -r requirements.txt
+


### PR DESCRIPTION
## Summary
- add `scripts/setup_test_env.sh` for installing dependencies
- document how to run the tests in new README "Testing" section

## Testing
- `bash scripts/setup_test_env.sh` *(fails: Could not install torch)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6872f32d593083298f2ca38e5e595134