### PR TITLE
Fix trailing whitespace in Python files

### DIFF
--- a/lit_gpt/config.py
+++ b/lit_gpt/config.py
@@ -243,7 +243,7 @@ for c in falcon:
 # StatNLP Research
 #############################
 leoleg = [
-     
+
     # https://twitter.com/cwolferesearch/status/1691929174175264858
     dict(
         org="StatNLP-research",

--- a/lit_gpt/rmsnorm.py
+++ b/lit_gpt/rmsnorm.py
@@ -799,7 +799,7 @@ class DropoutAddLayerNorm(torch.nn.Module):
             prenorm=self.prenorm,
             residual_in_fp32=self.residual_in_fp32,
         )
-        
+
 def rms_norm(x, weight, epsilon):
     return DropoutAddLayerNormFn.apply(
         x, None, weight, None, None, None, 0.0, epsilon, False, False, True
@@ -817,8 +817,8 @@ class FusedRMSNorm(torch.nn.Module):
 
     def forward(self, x):
         return rms_norm(x, self.weight, self.eps)
-    
-    
+
+
 class RMSNorm(torch.nn.Module):
     """Root Mean Square Layer Normalization.
 

--- a/lit_gpt/speed_monitor.py
+++ b/lit_gpt/speed_monitor.py
@@ -252,7 +252,7 @@ class SpeedMonitorBase:
             )
             if lengths is not None:
                 elapsed_lengths = int(self.history_lengths[-1]) - int(self.history_lengths[0])
-                avg_length = elapsed_lengths / elapsed_batches  
+                avg_length = elapsed_lengths / elapsed_batches
                 metrics.update(
                     {
                         "throughput/tokens_per_sec": samples_per_sec * avg_length,

--- a/pretrain/leoleg_code.py
+++ b/pretrain/leoleg_code.py
@@ -31,7 +31,7 @@ learning_rate = 2e-4
 min_lr = 2e-5
 micro_batch_size = 6
 max_step = 10000
-warmup_steps = 0 
+warmup_steps = 0
 log_step_interval = 1
 eval_iters = 1000000
 save_step_interval = 2000
@@ -131,14 +131,14 @@ def main(fabric, train_data_dir, val_data_dir, resume):
     t0 = time.perf_counter()
     with fabric.init_module(empty_init=True):
         model = GPT(config)
-    
- 
+
+
     model = fabric.setup(model)
     fabric.load_raw(checkpoint_path, model, strict=True)
     fabric.print(f"Time to instantiate model: {time.perf_counter() - t0:.02f} seconds.")
     fabric.print(f"Total parameters {num_parameters(model):,}")
 
-    
+
     optimizer = torch.optim.AdamW(
         model.parameters(), lr=learning_rate, weight_decay=weight_decay, betas=(beta1, beta2), foreach=False
     )
@@ -191,11 +191,11 @@ def train(fabric, state, train_dataloader, val_dataloader, monitor, resume):
         import torch_xla.core.xla_model as xm
 
         xm.mark_step()
-    
-    
+
+
     initial_iter = state["iter_num"]
     curr_iter = 0
-            
+
     loss_func = FusedCrossEntropyLoss()
     for  train_data in train_dataloader:
         # resume loader state. This is not elegant but it works. Should rewrite it in the future.
@@ -210,7 +210,7 @@ def train(fabric, state, train_dataloader, val_dataloader, monitor, resume):
                 fabric.print("resume finished, taken {} seconds".format(time.perf_counter() - total_t0))
         if state["iter_num"] >= max_iters:
             break
-        
+
         # determine and set the learning rate for this iteration
         lr = get_lr(state["iter_num"]) if decay_lr else learning_rate
         for param_group in optimizer.param_groups:
@@ -235,17 +235,17 @@ def train(fabric, state, train_dataloader, val_dataloader, monitor, resume):
         elif fabric.device.type == "xla":
             xm.mark_step()
         state["iter_num"] += 1
-        # input_id: B L 
+        # input_id: B L
         total_lengths += input_ids.size(1)
         t1 = time.perf_counter()
         fabric.print(
                 f"iter {state['iter_num']} step {state['step_count']}: loss {loss.item():.4f}, iter time:"
                 f" {(t1 - iter_t0) * 1000:.2f}ms{' (optimizer.step)' if not is_accumulating else ''}"
-                f" remaining time: {(t1 - total_t0) / (state['iter_num'] - initial_iter) * (max_iters - state['iter_num']) / 3600:.2f} hours. " 
+                f" remaining time: {(t1 - total_t0) / (state['iter_num'] - initial_iter) * (max_iters - state['iter_num']) / 3600:.2f} hours. "
                 # print days as well
                 f" or {(t1 - total_t0) / (state['iter_num'] - initial_iter) * (max_iters - state['iter_num']) / 3600 / 24:.2f} days. "
             )
- 
+
         monitor.on_train_batch_end(
             state["iter_num"] * micro_batch_size,
             t1 - total_t0,
@@ -257,11 +257,11 @@ def train(fabric, state, train_dataloader, val_dataloader, monitor, resume):
             train_loss = loss.item()
         )
 
-            
-            
-            
+
+
+
         if val_dataloader is not None and not is_accumulating and state["step_count"] % eval_step_interval == 0:
-            
+
             t0 = time.perf_counter()
             val_loss = validate(fabric, model, val_dataloader)
             t1 = time.perf_counter() - t0
@@ -275,7 +275,7 @@ def train(fabric, state, train_dataloader, val_dataloader, monitor, resume):
             fabric.print(f"Saving checkpoint to {str(checkpoint_path)!r}")
             fabric.save(checkpoint_path, state)
 
-        
+
 @torch.no_grad()
 def validate(fabric: L.Fabric, model: torch.nn.Module, val_dataloader: DataLoader) -> torch.Tensor:
     fabric.print("Validating ...")
@@ -293,7 +293,7 @@ def validate(fabric: L.Fabric, model: torch.nn.Module, val_dataloader: DataLoade
         # loss_func = FusedCrossEntropyLoss()
         # loss = loss_func(logits, targets)
         losses[k] = loss.item()
-        
+
     out = losses.mean()
 
     model.train()

--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -150,7 +150,7 @@ def copy_weights_llama(
         elif "transformer.h" in name:
             from_name, number = layer_template(name, 2)
             to_name = weight_map[from_name]
-            
+
             if to_name is None:
                 continue
             to_name = to_name.format(number)
@@ -267,16 +267,16 @@ def convert_config_lit_to_hf(lit_config_dict: dict) -> dict:
 
     }
     hf_config_dict = get_leoleg_init_hf_config()
-    
+
     for lit_key, hf_key in lit_hf_mapping.items():
         hf_config_dict[hf_key] = lit_config_dict[lit_key]
     return hf_config_dict
 
 
 @torch.inference_mode()
-def convert_lit_checkpoint(*, 
-    checkpoint_name: str, 
-    out_dir: Path, 
+def convert_lit_checkpoint(*,
+    checkpoint_name: str,
+    out_dir: Path,
     model_name: str,
     model_only: bool = True) -> None:
     config = Config.from_name(model_name)

--- a/scripts/prepare_slimpajama.py
+++ b/scripts/prepare_slimpajama.py
@@ -39,8 +39,8 @@ def prepare_full(
     tokenizer = Tokenizer(tokenizer_path)
 
     # Use the provided filenames_subset or default to all filenames
-    filenames = filenames_subset 
-    
+    filenames = filenames_subset
+
     if not filenames:
         raise RuntimeError(
             f"No files matching {slimpajama_sets[split]} found at {source_path}. \n"
@@ -82,8 +82,8 @@ def prepare(
 
     filenames = glob.glob(os.path.join(source_path, slimpajama_sets[split]), recursive=True)
     filenames = filenames[:int(len(filenames) * percentage)]
-    
-    num_processes = cpu_count() 
+
+    num_processes = cpu_count()
     chunked_filenames = np.array_split(filenames, num_processes)
 
     processes = []

--- a/scripts/prepare_starcoder.py
+++ b/scripts/prepare_starcoder.py
@@ -34,8 +34,8 @@ def prepare_full(
     tokenizer = Tokenizer(tokenizer_path)
 
     # Use the provided filenames_subset or default to all filenames
-    filenames = filenames_subset 
-    
+    filenames = filenames_subset
+
     if not filenames:
         raise RuntimeError(
             f"No files matching  found at {source_path}. \n"

--- a/sft/finetune.py
+++ b/sft/finetune.py
@@ -38,9 +38,9 @@ import evaluate
 from transformers.trainer_utils import PREFIX_CHECKPOINT_DIR
 
 
-    
 
-if torch.cuda.is_available():   
+
+if torch.cuda.is_available():
     torch.backends.cuda.matmul.allow_tf32 = True
 
 logger = logging.getLogger(__name__)
@@ -250,7 +250,7 @@ def smart_tokenizer_and_embedding_resize(
     """
     num_new_tokens = tokenizer.add_special_tokens(special_tokens_dict) + tokenizer.add_tokens(non_special_tokens)
     model.resize_token_embeddings(len(tokenizer))
-    
+
     if num_new_tokens > 0:
         input_embeddings_data = model.get_input_embeddings().weight.data
         output_embeddings_data = model.get_output_embeddings().weight.data
@@ -455,7 +455,7 @@ def make_data_module(tokenizer: transformers.PreTrainedTokenizer, args) -> Dict:
      # Load dataset.
     dataset = load_data(args.dataset)
     dataset = format_dataset(dataset, args.dataset_format)
- 
+
     # Split train/eval, reduce size
     if args.do_eval or args.do_predict:
         if 'eval' in dataset:
@@ -516,7 +516,7 @@ def train():
         **vars(model_args), **vars(data_args), **vars(training_args)
     )
     print(args)
-    
+
     checkpoint_dir, completed_training = get_last_checkpoint(args.output_dir)
     if completed_training:
         print('Detected that training was already completed!')
@@ -528,7 +528,7 @@ def train():
     set_seed(args.seed)
 
     data_module = make_data_module(tokenizer=tokenizer, args=args)
-    
+
     trainer = Seq2SeqTrainer(
         model=model,
         tokenizer=tokenizer,
@@ -537,10 +537,10 @@ def train():
     )
 
 
-   
-        
 
-        
+
+
+
 
     # Verifying the datatypes and parameter counts before training.
     print_trainable_parameters(args, model)


### PR DESCRIPTION
## Summary
- strip trailing spaces in config and script files
- remove stray whitespace in models and utils
- clean all Python files so grep finds no trailing spaces

## Testing
- `grep -nPl '\s+$' $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6872f49c4c8c832982619e9eccfae2d1