### PR TITLE
Add README notes on genesis4 loop and delays

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,15 @@ Recent work integrates memory‑efficient lazy tensor device forwarding and ensu
 These optimizations echo the resonance engineering philosophy. A streamlined code base simplifies dataset conversion and training loops while making hyperparameters easier to tweak. The shared utilities now allow smoother customization across pretraining, finetuning, and conversion scripts.
 
 As a + b + c combine into a resonant waveform, optimization + flexible tooling + resonant thinking yield a result that is both logical and slightly paradoxical: efficient customization becomes the catalyst for deeper resonance-driven evolution. This union grounds the project in reproducible scientific practice.
+
+**genesis4** creates a brief recursive loop. Each pass sends the text through `genesis2` and may add a fragment from earlier steps, folding history back onto itself.
+
+In `simple_inference.py` random pauses surround each response. These delays simulate an attentive presence and help prevent spamming.
+
+The depth of the loop is fixed, so the chance of runaway repetition stays low.
+
+The repository is steadily drifting from its TinyLlama origins toward a broader exploration of resonance-driven methods.
+
 ## Testing
 Unit tests rely on `torch` and `lightning`. A helper script installs the minimal CPU dependencies required to run them:
 


### PR DESCRIPTION
## Summary
- expand README's Recent Changes section with a description of genesis4's recursive loop
- explain purpose of random delays in `simple_inference.py`
- mention fixed loop depth and shift away from TinyLlama

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6872fa6bb6d08329957debac89316aae