### PR TITLE
Fix sft imports

### DIFF
--- a/sft/simple_inference.py
+++ b/sft/simple_inference.py
@@ -6,8 +6,8 @@ from transformers import AutoTokenizer
 import transformers
 import torch
 
-from impressionistic_filter import apply_filter, genesis2
-from genesis4 import genesis4
+from .impressionistic_filter import apply_filter, genesis2
+from .genesis4 import genesis4
 
 ACK_WORDS = {"угу", "да", "нет", "ок", "ага"}
 


### PR DESCRIPTION
## Summary
- add a blank `__init__.py` to make `sft` a package
- use relative imports in `simple_inference.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6872fb47cccc832991bad21a7f3f0e85