### PR TITLE
Add tests for genesis4 and inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ pytest
 ```
 
 The script pulls the CPU builds of PyTorch and Lightning and installs the rest of the packages listed in `requirements.txt`.
+Additional tests verify the `genesis4` recursion and the `simple_inference` helper. The first ensures the looped transformation changes the text length, and the second mocks the transformers pipeline and pauses so the CLI can be exercised quickly.
 ## License
 This project is licensed under the Apache 2.0 license as declared in the
 [LICENSE](LICENSE) file.

--- a/tests/test_genesis4.py
+++ b/tests/test_genesis4.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+import random
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from sft.genesis4 import genesis4
+import pytest
+
+@pytest.mark.parametrize("kwargs", [
+    {},
+    {"depth": 2, "glyph_prob": 1.0, "shuffle_prob": 0.5, "echo_chance": 0.5},
+])
+def test_genesis4_mutates_text(kwargs):
+    random.seed(0)
+    text = "A B C"
+    result = genesis4(text, **kwargs)
+    assert isinstance(result, str)
+    assert len(result) != len(text)

--- a/tests/test_simple_inference.py
+++ b/tests/test_simple_inference.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+import importlib
+import types
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("transformers")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+si = importlib.import_module("sft.simple_inference")
+
+
+def test_simple_inference_cli(monkeypatch):
+    captured = {}
+
+    def fake_pipeline(*args, **kwargs):
+        def run(prompt, **k):
+            captured["prompt"] = prompt
+            return [{"generated_text": "text"}]
+        return run
+
+    monkeypatch.setattr(si.transformers, "pipeline", fake_pipeline)
+    monkeypatch.setattr(si.AutoTokenizer, "from_pretrained", lambda *a, **k: object())
+    monkeypatch.setattr(si.time, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(si, "apply_filter", lambda *a, **k: None)
+    monkeypatch.setattr(si, "genesis4", lambda t: t + " follow")
+    monkeypatch.setattr(sys, "argv", ["prog", "Prompt"])
+
+    si.main()
+    assert captured["prompt"].startswith("<|im_start|>")


### PR DESCRIPTION
## Summary
- add parameterized tests for `genesis4`
- add mocked CLI test for `simple_inference`
- document the new tests in the README

## Testing
- `bash scripts/setup_test_env.sh` *(fails: Could not install torch)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6872fb55e1dc83299c92ffe2004fbe33