### PR TITLE
Pin stable torch

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ surprisingly stable behavior.
 
 
 ## Installation
-The project expects CUDA 11.8. Install PyTorch nightly and build XFormers and Flash-Attention 2 from source:
+The project expects CUDA 11.8. Install PyTorch 2.1.0 and build XFormers and Flash-Attention 2 from source:
 ```bash
-pip install --index-url https://download.pytorch.org/whl/nightly/cu118 --pre 'torch>=2.1.0dev'
+pip install --index-url https://download.pytorch.org/whl/cu118 torch==2.1.0
 # build xformers
 pip uninstall ninja -y && pip install ninja -U
 pip install -v -U git+https://github.com/facebookresearch/xformers.git@main#egg=xformers

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch>=2.1.0dev
+torch==2.1.0
 lightning==2.1.2
 lightning[app]
 jsonargparse[signatures]  # CLI


### PR DESCRIPTION
## Summary
- pin `torch` to the stable 2.1.0 release
- update installation instructions for the stable wheel

## Testing
- `bash scripts/setup_test_env.sh` *(fails: could not download torch due to network)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68730e7753688329a415500976ebb294